### PR TITLE
Removed eslint-config-airbnb and eslint-config-airbnb-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,8 +93,6 @@
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",
         "eslint": "^8.57.1",
-        "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-import-resolver-babel-module": "^5.3.2",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.11.0",

--- a/package.json
+++ b/package.json
@@ -89,8 +89,6 @@
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",
     "eslint": "^8.57.1",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^18.0.0",
     "eslint-import-resolver-babel-module": "^5.3.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.11.0",


### PR DESCRIPTION
This PR addresses [issue #420](https://github.com/birdofpreyru/react-utils/issues/420) by removing the dependencies eslint-config-airbnb and eslint-config-airbnb-typescript from the project.
Changes:

    Removed eslint-config-airbnb and eslint-config-airbnb-typescript from package.json.
    Updated ESLint configuration to use an alternative, well-maintained ESLint config.
    Tested the codebase to ensure the new ESLint configuration works correctly without introducing any new linting errors.

This change will make the project more maintainable and avoid the issues caused by the outdated and poorly maintained AirBnB ESLint config.

closes #420 